### PR TITLE
update carthage path

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -592,7 +592,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "/opt/homebrew/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
This pull request updates the `PalaceAudiobookToolkit.xcodeproj` project configuration to reflect a change in the path to the Carthage executable.

Build configuration update:

* Updated the `shellScript` property in a `PBXShellScriptBuildPhase` to use the new path `/opt/homebrew/bin/carthage` instead of `/usr/local/bin/carthage`.